### PR TITLE
go get --> go install

### DIFF
--- a/.github/workflows/preview_generate.yml
+++ b/.github/workflows/preview_generate.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Generate preview
         working-directory: ./steps
         run: |
-          go get github.com/googlecodelabs/tools/claat
+          go install github.com/googlecodelabs/tools/claat@latest
           $HOME/go/bin/claat export index.lab.md
       - name: Save PR number
         run: |


### PR DESCRIPTION
`go get` has been deprecated in favor of `go install`: https://go.dev/doc/go-get-install-deprecation