### PR TITLE
chore(*): update gradle-versions plugin to 0.54.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.android.library") version "9.0.0" apply false
     id("org.jetbrains.kotlin.android") version "2.3.0" apply false
     id("com.google.gms.google-services") version "4.4.4" apply false
-    id("com.github.ben-manes.versions") version "0.53.0" apply true
+    id("com.github.ben-manes.versions") version "0.54.0" apply true
 }
 
 allprojects {


### PR DESCRIPTION
This should fix the `java.util.ConcurrentModificationException` that is thrown in dpebot builds (full context in https://github.com/GoogleCloudPlatform/repository-gardener/issues/200), causing the bot to not update dependencies in this repo. (meaning the bot will resume once this is merged)